### PR TITLE
Handle non-version filenames under binaries folder

### DIFF
--- a/company-tabnine.el
+++ b/company-tabnine.el
@@ -320,6 +320,7 @@ Resets every time successful completion is returned.")
                                           it
                                           (file-name-as-directory
                                            parent))))
+                              (--filter (ignore-errors (version-to-list it)))
                               (-non-nil)))
                (sorted (nreverse (sort children #'version<)))
                (target (company-tabnine--get-target))


### PR DESCRIPTION
When there is a file that's not named like a version under the
binaries folder, `company-tabnine--executable-path` would error out. This happens when I set the binaries folder to `~/.local/share/TabNine` so that my home directory is clean. Deep TabNine stores its models in the same directory, and that triggers the problem.

This PR filters out those names (by testing if `version-to-list` works) before
sorting the list with `version<`.