### PR TITLE
Run x86_64 TabNine on aarch64-darwin

### DIFF
--- a/company-tabnine.el
+++ b/company-tabnine.el
@@ -283,7 +283,8 @@ Resets every time successful completion is returned.")
   (let* ((system-architecture (car (s-split "-" system-configuration)))
          (tabnine-architecture
           (cond
-           ((string= system-architecture "x86_64")
+           ((or (and (string= system-architecture "aarch64") (eq system-type 'darwin))
+                (string= system-architecture "x86_64"))
             "x86_64")
            ((string-match system-architecture "i.86")
             "i686")

--- a/company-tabnine.el
+++ b/company-tabnine.el
@@ -280,27 +280,30 @@ Resets every time successful completion is returned.")
 
 (defun company-tabnine--get-target ()
   "Return TabNine's system configuration.  Used for finding the correct binary."
-  (let ((architecture
-         (cond
-          ((string= (s-left 6 system-configuration) "x86_64")
-           "x86_64")
-          (t
-           "i686")))
+  (let* ((system-architecture (car (s-split "-" system-configuration)))
+         (tabnine-architecture
+          (cond
+           ((string= system-architecture "x86_64")
+            "x86_64")
+           ((string-match system-architecture "i.86")
+            "i686")
+           (t
+            (error "Unknown or unsupported architecture %s" system-architecture))))
 
-        (os
-         (cond
-          ((or (eq system-type 'ms-dos)
-               (eq system-type 'windows-nt)
-               (eq system-type 'cygwin))
-           "pc-windows-gnu")
-          ((or (eq system-type 'darwin))
-           "apple-darwin")
-          (company-tabnine-install-static-binary
-           "unknown-linux-musl")
-          (t
-           "unknown-linux-gnu"))))
+         (os
+          (cond
+           ((or (eq system-type 'ms-dos)
+                (eq system-type 'windows-nt)
+                (eq system-type 'cygwin))
+            "pc-windows-gnu")
+           ((or (eq system-type 'darwin))
+            "apple-darwin")
+           (company-tabnine-install-static-binary
+            "unknown-linux-musl")
+           (t
+            "unknown-linux-gnu"))))
 
-    (concat architecture "-" os)))
+    (concat tabnine-architecture "-" os)))
 
 (defun company-tabnine--get-exe ()
   "Return TabNine's binary file name.  Used for finding the correct binary."


### PR DESCRIPTION
The current architecture check falls back to i686 for native Emacs builds on Apple Silicon, which have a `system-configuration` of `aarch64-apple-darwin20.1.0` (at least, the copy I compiled with MacPorts does). 32-bit x86 binaries will not run on any Apple hardware since macOS Catalina, certainly not on ARM.

Assuming the user has Rosetta installed, the x86_64 build of TabNine runs on such systems. I believe that the user will see a prompt to install Rosetta if it is not installed already, but I am not entirely sure. I think it's fairly safe to assume Emacs users will already be using Rosetta anyway.