### PR TITLE
Support new bundle format

### DIFF
--- a/company-tabnine.el
+++ b/company-tabnine.el
@@ -630,19 +630,20 @@ Return completion candidates.  Must be called after `company-tabnine-query'."
         (error "TabNine installation failed.  Please try again"))
       (message "Current version is %s" version)
       (let* ((url (concat "https://update.tabnine.com/bundles/" version "/" target "/TabNine.zip"))
-             (target-directory (file-name-as-directory
-                                (concat
-                                 (file-name-as-directory
-                                  (concat (file-name-as-directory binaries-dir) version))
-                                 target)))
-             (bundle-path (expand-file-name "TabNine.zip" target-directory))
+             (version-directory (file-name-as-directory
+                                 (concat
+                                  (file-name-as-directory
+                                   (concat (file-name-as-directory binaries-dir) version)))))
+             (target-directory (file-name-as-directory (concat version-directory target) ))
+             (bundle-path (concat version-directory (format "%s.zip" target)))
              (target-path (concat target-directory exe)))
         (message "Installing at %s. Downloading %s ..." target-path url)
-        (make-directory target-directory t)
+        (make-directory version-directory t)
         (url-copy-file url bundle-path t)
-        (shell-command (format "unzip -o %s -d %s" bundle-path target-directory))
-        (mapc (lambda (path)
-                (set-file-modes (concat target-directory path) (string-to-number "744" 8)))
+        (let ((default-directory version-directory))
+          (dired-compress-file (file-name-nondirectory bundle-path)))
+        (mapc (lambda (filename)
+                (set-file-modes (concat target-directory filename) (string-to-number "744" 8)))
               (--remove (member it '("." "..")) (directory-files target-directory)))
         (delete-file bundle-path)
         (delete-file version-tempfile)

--- a/company-tabnine.el
+++ b/company-tabnine.el
@@ -624,26 +624,29 @@ Return completion candidates.  Must be called after `company-tabnine-query'."
     (message version-tempfile)
     (message "Getting current version...")
     (make-directory (file-name-directory version-tempfile) t)
-    (url-copy-file "https://update.tabnine.com/version" version-tempfile t)
+    (url-copy-file "https://update.tabnine.com/bundles/version" version-tempfile t)
     (let ((version (s-trim (with-temp-buffer (insert-file-contents version-tempfile) (buffer-string)))))
       (when (= (length version) 0)
         (error "TabNine installation failed.  Please try again"))
       (message "Current version is %s" version)
-      (let ((url (concat "https://update.tabnine.com/" version "/" target "/" exe)))
-        (let ((target-path
-               (concat
-                (file-name-as-directory
-                 (concat
-                  (file-name-as-directory
-                   (concat (file-name-as-directory binaries-dir) version))
-                  target))
-                exe)))
-          (message "Installing at %s. Downloading %s ..." target-path url)
-          (make-directory (file-name-directory target-path) t)
-          (url-copy-file url target-path t)
-          (set-file-modes target-path (string-to-number "744" 8))
-          (delete-file version-tempfile)
-          (message "TabNine installation complete."))))))
+      (let* ((url (concat "https://update.tabnine.com/bundles/" version "/" target "/TabNine.zip"))
+             (target-directory (file-name-as-directory
+                                (concat
+                                 (file-name-as-directory
+                                  (concat (file-name-as-directory binaries-dir) version))
+                                 target)))
+             (bundle-path (expand-file-name "TabNine.zip" target-directory))
+             (target-path (concat target-directory exe)))
+        (message "Installing at %s. Downloading %s ..." target-path url)
+        (make-directory target-directory t)
+        (url-copy-file url bundle-path t)
+        (shell-command (format "unzip -o %s -d %s" bundle-path target-directory))
+        (mapc (lambda (path)
+                (set-file-modes (concat target-directory path) (string-to-number "744" 8)))
+              (--remove (member it '("." "..")) (directory-files target-directory)))
+        (delete-file bundle-path)
+        (delete-file version-tempfile)
+        (message "TabNine installation complete.")))))
 
 (defun company-tabnine-call-other-backends ()
   "Invoke company completion but disable TabNine once, passing query to other backends in `company-backends'.

--- a/fetch-binaries.sh
+++ b/fetch-binaries.sh
@@ -1,24 +1,24 @@
 #!/bin/sh
 set -e
 
-version=$(curl -sS https://update.tabnine.com/version)
-targets=(
-    i686-apple-darwin
+# This script downloads the binaries for the most recent version of TabNine.
+
+version="$(curl -sS https://update.tabnine.com/bundles/version)"
+targets='i686-pc-windows-gnu
+    i686-unknown-linux-musl
     x86_64-apple-darwin
-    x86_64-unknown-linux-gnu
     x86_64-pc-windows-gnu
-    i686-unknown-linux-gnu
-    i686-pc-windows-gnu
-)
-for target in ${targets[@]}
+    x86_64-unknown-linux-musl'
+
+rm -rf ./binaries
+
+echo "$targets" | while read target
 do
     mkdir -p binaries/$version/$target
-    case $target in
-        *windows*) exe=TabNine.exe ;;
-        *) exe=TabNine ;;
-    esac
-    path=$version/$target/$exe
+    path=$version/$target
     echo "downloading $path"
-    curl -sS https://update.tabnine.com/$path > binaries/$path
-    chmod +x binaries/$path
+    curl -sS https://update.tabnine.com/bundles/$path/TabNine.zip > binaries/$path/TabNine.zip
+    unzip -o binaries/$path/TabNine.zip -d binaries/$path
+    rm binaries/$path/TabNine.zip
+    chmod +x binaries/$path/*
 done


### PR DESCRIPTION
It seems that Codota have changed the download format for TabNine binaries. They are now distributed in zip files. [source](https://github.com/codota/TabNine/blob/master/dl_binaries.sh)

These commits enable versions distributed in this format to be downloaded and installed correctly.

It assumes the user has `unzip` in their path. This might not be true on certain platforms, but upstream's downloader makes the same assumption.