### PR TITLE
Add js2-mode settings snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ With [Deep TabNine](https://tabnine.com/blog/deep):
    ```emacs
    (add-to-list 'company-backends #'company-tabnine)
    ```
-
+   If you are using `js2-mode`:
+   ```emacs
+   (after! js2-mode
+      (set-company-backend! 'js2-mode #'company-tabnine))
+   ```
 4. Run `M-x company-tabnine-install-binary` to install the TabNine binary for your system.
 
 ## Recommended Configuration


### PR DESCRIPTION
Add a code snippet to make tabnine-company work with js2-mode.
It is better for js2-mode users, and mostly with Doom Emacs users that use js2-mode as default javascript mode. The company code snippet in the README.md most of the times don't work with Doom Emacs users that use it default configuration for javascript.